### PR TITLE
Handle empty yaml files

### DIFF
--- a/python/desc/gen3_workflow/gather_resource_info.py
+++ b/python/desc/gen3_workflow/gather_resource_info.py
@@ -26,6 +26,7 @@ def parse_metadata_yaml(yaml_file):
     results = dict()
     with open(yaml_file) as fd:
         md = yaml.safe_load(fd)
+        md = {} if md is None else md
     methods = list(md.keys())
     for method in methods:
         for key, value in md[method].items():


### PR DESCRIPTION
Currently it fails in case a yaml file is empty since `md` is of type None.
This is a suggestion to handle this case, although it is not clear yet to me why a metadata yaml file can be empty.
