### PR TITLE
Update submit function signature

### DIFF
--- a/python/desc/gen3_workflow/parsl_service.py
+++ b/python/desc/gen3_workflow/parsl_service.py
@@ -690,7 +690,7 @@ class ParslService(BaseWmsService):
         print(f'Run Name: {workflow.name}')
         return workflow
 
-    def submit(self, workflow):
+    def submit(self, workflow, **kwargs):
         """
         Submit a workflow for execution.
 


### PR DESCRIPTION
The `submit` method signature in `ctrl_bps` updated to accept (and pass) extraneous keyword arguments which is not compatible with the signature here. With Patricia Larsen, we figured passing this is necessary to use the Parsl plugin at NERSC.

Relevant change in `ctrl_bps`: https://github.com/lsst/ctrl_bps/pull/138